### PR TITLE
7 access user summary from linkedin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@
 
 #Ignore public assets
 /public/assets/*
+
+#Ignore VCR cassettes
+/spec/cassettes/*

--- a/Gemfile
+++ b/Gemfile
@@ -33,5 +33,10 @@ group :development do
   gem 'listen', '~> 3.0.5'
 end
 
+group :test do
+  gem 'vcr'
+  gem 'webmock'
+end
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,8 @@ GEM
       execjs
     coffee-script-source (1.10.0)
     concurrent-ruby (1.0.2)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     docile (1.1.5)
@@ -72,6 +74,7 @@ GEM
       thor (~> 0.14)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
+    hashdiff (0.3.0)
     hashie (3.4.4)
     i18n (0.7.0)
     jbuilder (2.6.0)
@@ -172,6 +175,7 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
+    safe_yaml (1.0.4)
     sass (3.4.22)
     sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
@@ -199,11 +203,16 @@ GEM
       thread_safe (~> 0.1)
     uglifier (3.0.0)
       execjs (>= 0.3.0, < 3)
+    vcr (3.0.3)
     web-console (3.3.1)
       actionview (>= 5.0)
       activemodel (>= 5.0)
       debug_inspector
       railties (>= 5.0)
+    webmock (2.1.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -233,7 +242,9 @@ DEPENDENCIES
   simplecov
   tzinfo-data
   uglifier (>= 1.3.0)
+  vcr
   web-console
+  webmock
 
 BUNDLED WITH
    1.12.5

--- a/app/controllers/profile_summaries_controller.rb
+++ b/app/controllers/profile_summaries_controller.rb
@@ -1,5 +1,5 @@
 class ProfileSummariesController < ApplicationController
   def show
-    @summary = ProfileSummary.get_text(current_user).summary
+    @summary = ProfileSummary.get_text(current_user)
   end
 end

--- a/app/controllers/profile_summaries_controller.rb
+++ b/app/controllers/profile_summaries_controller.rb
@@ -1,0 +1,5 @@
+class ProfileSummariesController < ApplicationController
+  def show
+    @summary = ProfileSummary.get_text(current_user).summary
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,4 @@
 class UsersController < ApplicationController
   def show
   end
-
 end

--- a/app/models/profile_summary.rb
+++ b/app/models/profile_summary.rb
@@ -1,14 +1,8 @@
 class ProfileSummary < ActiveRecord::Base
   belongs_to :user
 
-  attr_reader :summary
-
-  def initialize(profile_data)
-    @summary = profile_data["summary"]
-  end
-
   def self.get_text(user)
     data = LinkedinService.new.get_profile_information(user.oauth_token)
-    ProfileSummary.new(data)
+    ProfileSummary.create!(content: data["summary"], user: user)
   end
 end

--- a/app/models/profile_summary.rb
+++ b/app/models/profile_summary.rb
@@ -1,0 +1,12 @@
+class ProfileSummary
+  attr_reader :summary
+
+  def initialize(profile_data)
+    @summary = profile_data["summary"]
+  end
+
+  def self.get_text(user)
+    data = LinkedinService.new.get_profile_information(user.oauth_token)
+    ProfileSummary.new(data)
+  end
+end

--- a/app/models/profile_summary.rb
+++ b/app/models/profile_summary.rb
@@ -1,4 +1,6 @@
-class ProfileSummary
+class ProfileSummary < ActiveRecord::Base
+  belongs_to :user
+
   attr_reader :summary
 
   def initialize(profile_data)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,8 +4,14 @@ class User < ApplicationRecord
     user.update_attributes(
       uid:         auth_hash.uid,
       name:        auth_hash.info.name,
+      first_name:  auth_hash.info.first_name,
+      last_name:   auth_hash.info.last_name,
       oauth_token: auth_hash.credentials.token
     )
     user
+  end
+
+  def to_param
+    "#{first_name.parameterize}"
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  has_one :profile_summary
+  
   def self.from_omniauth(auth_hash)
     user = User.find_or_create_by(uid: auth_hash["uid"])
     user.update_attributes(

--- a/app/services/linkedin_service.rb
+++ b/app/services/linkedin_service.rb
@@ -1,0 +1,14 @@
+class LinkedinService
+  def get_profile_summary
+    # response = Faraday.get("https://api.linkedin.com/v1/people/~:(summary)?format=json")
+
+
+    connection = Faraday.new("https://api.linkedin.com")
+    connection.headers = {"Authorization" => "Bearer AQUYWUPxIxJE-eTwk_4uYVCPx86rUr3xmcMQQ3OUJ0iT8SzAUvnm5VRiiB1wfZD26Iux1sauvEqc0KFAVyu0Kk8F4UBv6tm8wCt29I_Z95qX4cWRE5fMhPVna2F7YFOg7IlHn_4NOkG4qB0Cm3XmUU8OUjE_GzHCB6Fh6jBrQvwYZaBIG4I"}
+
+    response = connection.get("/v1/people/~:(summary)?format=json")
+
+    JSON.parse(response.body)
+  end
+
+end

--- a/app/services/linkedin_service.rb
+++ b/app/services/linkedin_service.rb
@@ -1,14 +1,12 @@
 class LinkedinService
-  def get_profile_summary
-    # response = Faraday.get("https://api.linkedin.com/v1/people/~:(summary)?format=json")
 
-
-    connection = Faraday.new("https://api.linkedin.com")
-    connection.headers = {"Authorization" => "Bearer AQUYWUPxIxJE-eTwk_4uYVCPx86rUr3xmcMQQ3OUJ0iT8SzAUvnm5VRiiB1wfZD26Iux1sauvEqc0KFAVyu0Kk8F4UBv6tm8wCt29I_Z95qX4cWRE5fMhPVna2F7YFOg7IlHn_4NOkG4qB0Cm3XmUU8OUjE_GzHCB6Fh6jBrQvwYZaBIG4I"}
-
-    response = connection.get("/v1/people/~:(summary)?format=json")
-
-    JSON.parse(response.body)
+  def initialize
+    @connection = Faraday.new("https://api.linkedin.com")
   end
 
+  def get_profile_information(oauth_token, profile_field="summary", format="json")
+    @connection.headers = {"Authorization" => "Bearer #{oauth_token}"}
+    response = @connection.get("/v1/people/~:(#{profile_field})?format=#{format}")
+    JSON.parse(response.body)
+  end
 end

--- a/app/views/profile_summaries/show.html.erb
+++ b/app/views/profile_summaries/show.html.erb
@@ -1,6 +1,6 @@
 <div id="profile-summary">
   <h1>Profile Summary</h1>
   <p>
-    <%= @summary %>
+    <%= @summary.content %>
   </p>
 </div>

--- a/app/views/profile_summaries/show.html.erb
+++ b/app/views/profile_summaries/show.html.erb
@@ -1,0 +1,6 @@
+<div id="profile-summary">
+  <h1>Profile Summary</h1>
+  <p>
+    <%= @summary %>
+  </p>
+</div>

--- a/app/views/welcome/show.html.erb
+++ b/app/views/welcome/show.html.erb
@@ -3,8 +3,8 @@
   <div class="welcome-content text-center">
     <h1>Welcome to WriteLink</h1>
     <h2>Personalized Content Analysis</h2>
-    <h2>You use LinkedIn to connect to to the professional world. <br>
+    <p>You use LinkedIn to connect to to the professional world. <br>
       Use WriteLink to analyze your writing and improve the way you present your professional self.
-    </h2>
+    </p>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,9 @@ Rails.application.routes.draw do
   delete '/logout' => 'sessions#destroy', as: :logout
 
   get '/:username' => "users#show", as: :user
+
+  scope '/:username' do
+    get '/profile_summary' => 'profile_summaries#show', as: :profile_summary
+  end
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,5 @@ Rails.application.routes.draw do
   get '/auth/linkedin/callback' => "sessions#create"
   delete '/logout' => 'sessions#destroy', as: :logout
 
-  resources :users, only: [:show]
+  get '/:username' => "users#show", as: :user
 end

--- a/db/migrate/20160730031419_add_columns_to_user.rb
+++ b/db/migrate/20160730031419_add_columns_to_user.rb
@@ -1,0 +1,6 @@
+class AddColumnsToUser < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :first_name, :string
+    add_column :users, :last_name, :string
+  end
+end

--- a/db/migrate/20160730033910_create_profile_summaries.rb
+++ b/db/migrate/20160730033910_create_profile_summaries.rb
@@ -1,0 +1,8 @@
+class CreateProfileSummaries < ActiveRecord::Migration[5.0]
+  def change
+    create_table :profile_summaries do |t|
+      t.text :content
+      t.references :user, foreign_key: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160727011100) do
+ActiveRecord::Schema.define(version: 20160730031419) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,8 @@ ActiveRecord::Schema.define(version: 20160727011100) do
     t.string   "uid"
     t.string   "name"
     t.string   "oauth_token"
+    t.string   "first_name"
+    t.string   "last_name"
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160730031419) do
+ActiveRecord::Schema.define(version: 20160730033910) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "profile_summaries", force: :cascade do |t|
+    t.text    "content"
+    t.integer "user_id"
+    t.index ["user_id"], name: "index_profile_summaries_on_user_id", using: :btree
+  end
 
   create_table "users", force: :cascade do |t|
     t.datetime "created_at",  null: false
@@ -25,4 +31,5 @@ ActiveRecord::Schema.define(version: 20160730031419) do
     t.string   "last_name"
   end
 
+  add_foreign_key "profile_summaries", "users"
 end

--- a/spec/features/user_logs_in_with_linkedin_spec.rb
+++ b/spec/features/user_logs_in_with_linkedin_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "user logs in with linkedin" do
     visit '/'
     click_link "Log In with LinkedIn"
 
-    expect(current_path).to eq user_path(User.first)
+    expect(current_path).to eq "/john"
     expect(page).to have_content "Log Out"
     expect(page).not_to have_content "Log In with LinkedIn"
   end

--- a/spec/features/user_logs_in_with_linkedin_spec.rb
+++ b/spec/features/user_logs_in_with_linkedin_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "user logs in with linkedin" do
     visit '/'
     click_link "Log In with LinkedIn"
 
-    expect(current_path).to eq "/john"
+    expect(current_path).to eq user_path(User.find_by(first_name: "John"))
     expect(page).to have_content "Log Out"
     expect(page).not_to have_content "Log In with LinkedIn"
   end

--- a/spec/features/user_sees_their_profile_summary_spec.rb
+++ b/spec/features/user_sees_their_profile_summary_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "user sees their profile summary" do
       visit "/erin/profile_summary"
 
       within("#profile-summary") do
-        expect(page).to have_content user.profile_summary
+        expect(page).to have_content user.profile_summary.content
       end
     end
   end

--- a/spec/features/user_sees_their_profile_summary_spec.rb
+++ b/spec/features/user_sees_their_profile_summary_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.feature "user sees their profile summary" do
+  fixtures :users
+  scenario "when they visit the page for the summary" do
+    VCR.use_cassette("profile_summary") do
+      user = users(:erin)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+      visit "/erin/profile_summary"
+
+      within("#profile-summary") do
+        expect(page).to have_content user.profile_summary
+      end
+    end
+  end
+end

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -1,0 +1,4 @@
+erin:
+  uid: 1234
+  name: Erin
+  oauth_token: ENV["user_token"]

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -1,4 +1,6 @@
 erin:
   uid: 1234
-  name: Erin
+  name: Erin Greenhalgh
+  first_name: Erin
+  last_name: Greenhalgh
   oauth_token: ENV["user_token"]

--- a/spec/models/profile_summary_spec.rb
+++ b/spec/models/profile_summary_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe "profile summary" do
+  fixtures :users
+
+  it "creates a profile summary instance in db from API data" do
+    VCR.use_cassette(:profile_summary) do
+      user = users(:erin)
+
+      ps = ProfileSummary.get_text(user)
+      expect(ProfileSummary.first.content[0..14]).to eq "I set extremely"
+    end
+  end
+
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,14 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  fixtures :users
-
-  # it "gets the user's profile summary from linkedin" do
-  #   VCR.use_cassette(:profile_summary) do
-  #     user = users(:erin)
-  #
-  #     ps = ProfileSummary.get_text(user)
-  #     expect(ps.summary[0..14]).to eq "I set extremely"
-  #   end
-  # end
+  pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  fixtures :users
+
+  it "gets the user's profile summary from linkedin" do
+    VCR.use_cassette(:profile_summary) do
+      user = users(:erin)
+
+      ps = ProfileSummary.get_text(user)
+      expect(ps.summary[0..14]).to eq "I set extremely"
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,12 +3,12 @@ require 'rails_helper'
 RSpec.describe User, type: :model do
   fixtures :users
 
-  it "gets the user's profile summary from linkedin" do
-    VCR.use_cassette(:profile_summary) do
-      user = users(:erin)
-
-      ps = ProfileSummary.get_text(user)
-      expect(ps.summary[0..14]).to eq "I set extremely"
-    end
-  end
+  # it "gets the user's profile summary from linkedin" do
+  #   VCR.use_cassette(:profile_summary) do
+  #     user = users(:erin)
+  #
+  #     ps = ProfileSummary.get_text(user)
+  #     expect(ps.summary[0..14]).to eq "I set extremely"
+  #   end
+  # end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,6 +9,13 @@ require 'spec_helper'
 require 'rspec/rails'
 require 'capybara/rspec'
 require 'capybara/rails'
+require 'vcr'
+
+VCR.configure do |c|
+  c.cassette_library_dir = 'spec/cassettes'
+  c.hook_into :webmock
+  c.configure_rspec_metadata!
+end
 
 
 # Add additional requires below this line. Rails is not loaded until this point!

--- a/spec/services/linkedin_service_spec.rb
+++ b/spec/services/linkedin_service_spec.rb
@@ -1,12 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe "linkedin service" do
-  VCR.use_cassette("profile_summary") do
-    let(:linkedin_service) { LinkedinService.new }
+  fixtures :users
+  let(:linkedin_service) { LinkedinService.new }
 
-    scenario "returns the user's summary" do
-      data = linkedin_service.get_profile_summary
-      expect(data.count).to eq 1
+  scenario "returns the user's summary" do
+    VCR.use_cassette("profile_summary") do
+      user = users(:erin)
+      data = linkedin_service.get_profile_information(user.oauth_token)
+      expect(data.keys.count).to eq 1
       expect(data["summary"]).to be_truthy
     end
   end

--- a/spec/services/linkedin_service_spec.rb
+++ b/spec/services/linkedin_service_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe "linkedin service" do
+  VCR.use_cassette("profile_summary") do
+    let(:linkedin_service) { LinkedinService.new }
+
+    scenario "returns the user's summary" do
+      data = linkedin_service.get_profile_summary
+      expect(data.count).to eq 1
+      expect(data["summary"]).to be_truthy
+    end
+  end
+end


### PR DESCRIPTION
Closes #7 
User can see their profile summary from linked in on the profile summaries show page
-successfully hits API to grab user summary
-stores profile summary to the database
-displays the summary  at "/:user-first-name/profile_summary"
-everything tested, except for User model
-think about caching the API call instead of storing to db?
