### PR TITLE
add gems and manifest.yml for bluemix production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
+ruby '2.3.0'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.0.0'
@@ -13,6 +14,8 @@ gem 'figaro'
 gem 'oauth2'
 gem 'omniauth-linkedin-oauth2'
 gem 'bootstrap-sass', '~> 3.2.0'
+gem "cf-autoconfig", "~> 0.2.1"
+gem 'rails_12factor', group: :production
 
 
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,9 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    cf-autoconfig (0.2.1)
+      cf-runtime (= 0.2.0)
+    cf-runtime (0.2.0)
     coderay (1.1.1)
     coffee-rails (4.2.1)
       coffee-script (>= 2.2.0)
@@ -148,6 +151,11 @@ GEM
       nokogiri (~> 1.6.0)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
+    rails_12factor (0.0.3)
+      rails_serve_static_assets
+      rails_stdout_logging
+    rails_serve_static_assets (0.0.5)
+    rails_stdout_logging (0.0.5)
     railties (5.0.0)
       actionpack (= 5.0.0)
       activesupport (= 5.0.0)
@@ -226,6 +234,7 @@ DEPENDENCIES
   bootstrap-sass (~> 3.2.0)
   byebug
   capybara
+  cf-autoconfig (~> 0.2.1)
   coffee-rails (~> 4.2)
   figaro
   jbuilder (~> 2.5)
@@ -237,6 +246,7 @@ DEPENDENCIES
   pry
   puma (~> 3.0)
   rails (~> 5.0.0)
+  rails_12factor
   rspec-rails
   sass-rails (~> 5.0)
   simplecov
@@ -245,6 +255,9 @@ DEPENDENCIES
   vcr
   web-console
   webmock
+
+RUBY VERSION
+   ruby 2.3.0p0
 
 BUNDLED WITH
    1.12.5

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,9 @@
+applications:
+- path: .
+  memory: 1GB
+  instances: 1
+  domain: mybluemix.net
+  name: WriteLink
+  host: WriteLink
+  disk_quota: 1024M
+  command: bundle exec rake db:migrate && bundle exec rails s -p $PORT


### PR DESCRIPTION
-manifest is necessary for bluemix to run app
-when pushing app to prod, run cf push write_link -c null
not sure why this works but pushes app to prod

Closes #13 
