### PR TITLE
2 user analyzes profile text

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'simplecov'
   gem 'capybara'
+  gem 'launchy'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ group :development, :test do
   gem 'simplecov'
   gem 'capybara'
   gem 'launchy'
+  gem 'shoulda-matchers', '~> 3.1'
 end
 
 group :development do
@@ -40,6 +41,7 @@ end
 group :test do
   gem 'vcr'
   gem 'webmock'
+  gem 'database_cleaner'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,8 @@ GEM
       thor (>= 0.14, < 2.0)
     json (2.0.1)
     jwt (1.5.4)
+    launchy (2.4.3)
+      addressable (~> 2.3)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -239,6 +241,7 @@ DEPENDENCIES
   figaro
   jbuilder (~> 2.5)
   jquery-rails
+  launchy
   listen (~> 3.0.5)
   oauth2
   omniauth-linkedin-oauth2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,7 @@ GEM
     concurrent-ruby (1.0.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
+    database_cleaner (1.5.3)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     docile (1.1.5)
@@ -193,6 +194,8 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    shoulda-matchers (3.1.1)
+      activesupport (>= 4.0.0)
     simplecov (0.12.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
@@ -238,6 +241,7 @@ DEPENDENCIES
   capybara
   cf-autoconfig (~> 0.2.1)
   coffee-rails (~> 4.2)
+  database_cleaner
   figaro
   jbuilder (~> 2.5)
   jquery-rails
@@ -252,6 +256,7 @@ DEPENDENCIES
   rails_12factor
   rspec-rails
   sass-rails (~> 5.0)
+  shoulda-matchers (~> 3.1)
   simplecov
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -1,3 +1,11 @@
+h1, h2, h3, h4 {
+  font-family: 'Work Sans', sans-serif;
+}
+
+p {
+  font-family: 'Open Sans', sans-serif;
+}
+
 .background {
   background-color:#DBDBDB;
   height: 100vh;

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -1,6 +1,5 @@
 .background {
-  // background-color:#3C0991;
-  background-color:#3B338F;
+  background-color:#DBDBDB;
   height: 100vh;
 }
 

--- a/app/controllers/profile_summaries_controller.rb
+++ b/app/controllers/profile_summaries_controller.rb
@@ -2,4 +2,11 @@ class ProfileSummariesController < ApplicationController
   def show
     @summary = ProfileSummary.get_text(current_user)
   end
+
+  def create_report
+    report_generator = ReportGeneratorService.new
+    @report = report_generator.create_report_entry(current_user)
+    report_generator.create_tone_reports(current_user, @report)
+    redirect_to report_path(@report)
+  end
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,0 +1,5 @@
+class ReportsController < ApplicationController
+  def show
+    @report = Report.find(params[:id])
+  end
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,0 @@
-class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
-  layout 'mailer'
-end

--- a/app/models/emotion_tone.rb
+++ b/app/models/emotion_tone.rb
@@ -1,0 +1,3 @@
+class EmotionTone < ApplicationRecord
+  belongs_to :report
+end

--- a/app/models/language_tone.rb
+++ b/app/models/language_tone.rb
@@ -1,0 +1,3 @@
+class LanguageTone < ApplicationRecord
+  belongs_to :report
+end

--- a/app/models/profile_summary.rb
+++ b/app/models/profile_summary.rb
@@ -3,7 +3,7 @@ class ProfileSummary < ActiveRecord::Base
   has_many :reports
 
   def self.get_text(user)
-    data = LinkedinService.new.get_profile_information(user.oauth_token)
+    data = LinkedinService.new(user.oauth_token).get_profile_information
     ProfileSummary.create!(content: data["summary"], user: user)
   end
 end

--- a/app/models/profile_summary.rb
+++ b/app/models/profile_summary.rb
@@ -1,5 +1,6 @@
 class ProfileSummary < ActiveRecord::Base
   belongs_to :user
+  has_many :reports
 
   def self.get_text(user)
     data = LinkedinService.new.get_profile_information(user.oauth_token)

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -3,4 +3,6 @@ class Report < ApplicationRecord
   has_one :emotion_tone
   has_one :language_tone
   has_one :social_tone
+
+  validates :text, presence: true
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,0 +1,3 @@
+class Report < ApplicationRecord
+  belongs_to :profile_summary
+end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,3 +1,6 @@
 class Report < ApplicationRecord
   belongs_to :profile_summary
+  has_one :emotion_tone
+  has_one :language_tone
+  has_one :social_tone
 end

--- a/app/models/social_tone.rb
+++ b/app/models/social_tone.rb
@@ -1,0 +1,3 @@
+class SocialTone < ApplicationRecord
+  belongs_to :report
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
   has_one :profile_summary
-  
+
   def self.from_omniauth(auth_hash)
     user = User.find_or_create_by(uid: auth_hash["uid"])
     user.update_attributes(

--- a/app/services/linkedin_service.rb
+++ b/app/services/linkedin_service.rb
@@ -1,12 +1,17 @@
 class LinkedinService
 
-  def initialize
-    @connection = Faraday.new("https://api.linkedin.com")
+  def initialize(oauth_token)
+    @_connection = Faraday.new("https://api.linkedin.com")
+    @_connection.headers["Authorization"] = "Bearer #{oauth_token}"
   end
 
-  def get_profile_information(oauth_token, profile_field="summary", format="json")
-    @connection.headers = {"Authorization" => "Bearer #{oauth_token}"}
-    response = @connection.get("/v1/people/~:(#{profile_field})?format=#{format}")
+  def get_profile_information(profile_field="summary", format="json")
+    response = _connection.get("/v1/people/~:(#{profile_field})?format=#{format}")
     JSON.parse(response.body)
+  end
+
+  private
+  def _connection
+    @_connection
   end
 end

--- a/app/services/report_generator_service.rb
+++ b/app/services/report_generator_service.rb
@@ -1,0 +1,49 @@
+class ReportGeneratorService
+  def initialize
+    @_formatter = ToneDataFormatterService.new
+  end
+
+  def create_report_entry(user)
+    Report.create!(profile_summary: user.profile_summary,
+                   text:            user.profile_summary.content)
+  end
+
+  def create_emotion_tone(user, report)
+    tone = _formatter.emotion_attributes(user)
+    EmotionTone.create!(anger:  tone["anger"],
+                       disgust: tone["disgust"],
+                       fear:    tone["fear"],
+                       joy:     tone["joy"],
+                       sadness: tone["sadness"],
+                       report:  report)
+  end
+
+  def create_language_tone(user, report)
+    tone = _formatter.language_attributes(user)
+    LanguageTone.create!(analytical: tone["analytical"],
+                        confident:   tone["confident"],
+                        tentative:   tone["tentative"],
+                        report:      report)
+  end
+
+  def create_social_tone(user, report)
+    tone = _formatter.social_attributes(user)
+    SocialTone.create!(openness:         tone["openeness"],
+                      conscientiousness: tone["conscientiousness"],
+                      extraversion:      tone["extraversion"],
+                      agreeableness:     tone["agreeableness"],
+                      emotional_range:   tone["emotional_range"],
+                      report:            report)
+  end
+
+  def create_tone_reports(user, report)
+    create_emotion_tone(user, report)
+    create_language_tone(user, report)
+    create_social_tone(user, report)
+  end
+
+  private
+  def _formatter
+    @_formatter
+  end
+end

--- a/app/services/tone_analyzer_service.rb
+++ b/app/services/tone_analyzer_service.rb
@@ -1,17 +1,15 @@
 class ToneAnalyzerService
-  # attr_reader :connection
-
-  def initialze
-  end
 
   def analyze_text(user)
-    connection = Faraday.new("https://gateway.watsonplatform.net")
-    connection.params = {version: "2016-05-19", text: "#{user.profile_summary.content}"}
-    connection.headers = {"password"      => ENV["TONE_ANALYZER_PASSWORD"],
-                          "username"      => ENV["TONE_ANALYZER_USERNAME"],
-                          "Authorization" => "Basic #{ENV['TONE_ANALYZER_AUTHORIZATION']}"}
-    response = connection.get("/tone-analyzer/api/v3/tone")
-    JSON.parse(response.body)
+    Rails.cache.fetch("#{user.profile_summary.updated_at}-tone-report") do
+      connection = Faraday.new("https://gateway.watsonplatform.net")
+      connection.params = {version: "2016-05-19", text: "#{user.profile_summary.content}"}
+      connection.headers = {"password"      => ENV["TONE_ANALYZER_PASSWORD"],
+                            "username"      => ENV["TONE_ANALYZER_USERNAME"],
+                            "Authorization" => "Basic #{ENV['TONE_ANALYZER_AUTHORIZATION']}"}
+      response = connection.get("/tone-analyzer/api/v3/tone")
+      JSON.parse(response.body)
+    end
   end
 
 end

--- a/app/services/tone_analyzer_service.rb
+++ b/app/services/tone_analyzer_service.rb
@@ -1,0 +1,17 @@
+class ToneAnalyzerService
+  # attr_reader :connection
+
+  def initialze
+  end
+
+  def analyze_text(user)
+    connection = Faraday.new("https://gateway.watsonplatform.net")
+    connection.params = {version: "2016-05-19", text: "#{user.profile_summary.content}"}
+    connection.headers = {"password"      => ENV["TONE_ANALYZER_PASSWORD"],
+                          "username"      => ENV["TONE_ANALYZER_USERNAME"],
+                          "Authorization" => "Basic #{ENV['TONE_ANALYZER_AUTHORIZATION']}"}
+    response = connection.get("/tone-analyzer/api/v3/tone")
+    JSON.parse(response.body)
+  end
+
+end

--- a/app/services/tone_data_formatter_service.rb
+++ b/app/services/tone_data_formatter_service.rb
@@ -1,0 +1,44 @@
+class ToneDataFormatterService
+  def service
+    ToneAnalyzerService.new
+  end
+
+  def categories(user)
+    data = service.analyze_text(user)
+    data["document_tone"]["tone_categories"]
+  end
+
+  def emotion_tones(user)
+    categories(user)[0]
+  end
+
+  def language_tones(user)
+    categories(user)[1]
+  end
+
+  def social_tones(user)
+    categories(user)[2]
+  end
+
+  def round(score)
+    (score * 1000).to_i
+  end
+
+  def format_attributes(tones)
+    tones.map do |tone|
+      [tone["tone_id"], round(tone["score"])]
+    end.to_h
+  end
+
+  def emotion_attributes(user)
+    format_attributes(emotion_tones(user)["tones"])
+  end
+
+  def language_attributes(user)
+    format_attributes(language_tones(user)["tones"])
+  end
+
+  def social_attributes(user)
+    format_attributes(social_tones(user)["tones"])
+  end
+end

--- a/app/services/tone_data_formatter_service.rb
+++ b/app/services/tone_data_formatter_service.rb
@@ -38,7 +38,14 @@ class ToneDataFormatterService
     format_attributes(language_tones(user)["tones"])
   end
 
+  def format_social_tone_name(tone)
+    tone[0..-6]
+  end
+
   def social_attributes(user)
-    format_attributes(social_tones(user)["tones"])
+    data = format_attributes(social_tones(user)["tones"])
+    data.map do |key, value|
+      [format_social_tone_name(key), value]
+    end.to_h
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,7 @@
   <head>
     <title>PersonalProject</title>
     <%= csrf_meta_tags %>
-    <link href="https://fonts.googleapis.com/css?family=Work+Sans" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Work+Sans|Open+Sans" rel="stylesheet">
 
     <%= stylesheet_link_tag    'application', media: 'all' %>
     <%= javascript_include_tag 'application' %>

--- a/app/views/profile_summaries/show.html.erb
+++ b/app/views/profile_summaries/show.html.erb
@@ -1,6 +1,7 @@
-<div id="profile-summary">
+<div class="profile-summary-form">
   <h1>Profile Summary</h1>
-  <p>
-    <%= @summary.content %>
-  </p>
+  <%= form_for @summary, url: { action: "create_report" } do |f| %>
+    <%= f.text_area :content, readonly: "readonly", id: "profile-summary" %>
+    <%= f.submit "Analyze" %>
+  <% end %>
 </div>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -1,0 +1,30 @@
+<div id="report">
+  <h1>Version <%= @report.id %></h1>
+  <p> <%= @report.text %></p>
+
+  <div id="emotion">
+    <h1>Emotion Tones</h1>
+    Anger: <%= @report.emotion_tone.anger %>
+    Disgust: <%= @report.emotion_tone.disgust %>
+    Fear: <%= @report.emotion_tone.fear %>
+    Joy: <%= @report.emotion_tone.joy %>
+    Sadness: <%= @report.emotion_tone.sadness %>
+  </div>
+
+  <div id="language">
+    <h1>Language Styles</h1>
+    Analytical: <%= @report.language_tone.analytical %>
+    Confident: <%= @report.language_tone.confident %>
+    Tentative: <%= @report.language_tone.tentative %>
+  </div>
+
+  <div id="social">
+    <h1>Social Tendencies</h1>
+    Openness: <%= @report.social_tone.openness %>
+    Conscientiousness: <%= @report.social_tone.conscientiousness %>
+    Extraversion: <%= @report.social_tone.extraversion %>
+    Agreeableness: <%= @report.social_tone.agreeableness %>
+    Emotional Range: <%= @report.social_tone.emotional_range %>
+  </div>
+
+</div>

--- a/app/views/welcome/_navbar.html.erb
+++ b/app/views/welcome/_navbar.html.erb
@@ -1,0 +1,5 @@
+<div class="container-fluid">
+  <ul class="nav navbar-nav navbar-left">
+    <li class="navbar-brand">WriteLink</li>
+  </ul>
+</div>

--- a/app/views/welcome/show.html.erb
+++ b/app/views/welcome/show.html.erb
@@ -1,10 +1,10 @@
-<%= render partial: 'shared/navbar' %>
+<%= render partial: 'navbar' %>
 <div class="welcome-page">
   <div class="welcome-content text-center">
-    <h1>Welcome to WriteLink</h1>
-    <h2>Personalized Content Analysis</h2>
+    <h1>Personalized Analysis. Powerful Writing.</h1>
     <p>You use LinkedIn to connect to to the professional world. <br>
       Use WriteLink to analyze your writing and improve the way you present your professional self.
     </p>
+    <%= link_to "Log In with LinkedIn", linkedin_login_path, class: "btn btn-default btn-lg"%>
   </div>
 </div>

--- a/config/database.yml
+++ b/config/database.yml
@@ -23,13 +23,13 @@ default: &default
 
 development:
   <<: *default
-  database: personal_project_development
+  database: write_link_development
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
   # When left blank, postgres will use the default role. This is
   # the same name as the operating system user that initialized the database.
-  #username: personal_project
+  #username: write_link
 
   # The password associated with the postgres role (username).
   #password:
@@ -57,7 +57,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: personal_project_test
+  database: write_link_test
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -80,6 +80,6 @@ test:
 #
 production:
   <<: *default
-  database: personal_project_production
-  username: personal_project
-  password: <%= ENV['PERSONAL_PROJECT_DATABASE_PASSWORD'] %>
+  database: write_link_production
+  username: write_link
+  password: <%= ENV['WRITE_LINK_DATABASE_PASSWORD'] %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -21,7 +21,7 @@ Rails.application.configure do
       'Cache-Control' => 'public, max-age=172800'
     }
   else
-    config.action_controller.perform_caching = false
+    config.action_controller.perform_caching = true
 
     config.cache_store = :null_store
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -54,7 +54,7 @@ Rails.application.configure do
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque
-  # config.active_job.queue_name_prefix = "personal_project_#{Rails.env}"
+  # config.active_job.queue_name_prefix = "write_link_#{Rails.env}"
   config.action_mailer.perform_caching = false
 
   # Ignore bad email addresses and do not raise email delivery errors.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -20,7 +20,7 @@ Rails.application.configure do
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
-  config.action_controller.perform_caching = false
+  config.action_controller.perform_caching = true
 
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_personal_project_session'
+Rails.application.config.session_store :cookie_store, key: '_write_link_session'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,12 @@ Rails.application.routes.draw do
 
   scope '/:username' do
     get '/profile_summary' => 'profile_summaries#show', as: :profile_summary
+    get '/profile_summary/create_report' => 'profile_summaries#create_report', as: :create_report
+    patch '/profile_summary/create_report' => 'profile_summaries#create_report'
+  end
+
+  scope '/profile_summary' do
+    resources :reports, only: [:show]
   end
 
 end

--- a/db/migrate/20160731172339_add_time_stamps.rb
+++ b/db/migrate/20160731172339_add_time_stamps.rb
@@ -1,0 +1,5 @@
+class AddTimeStamps < ActiveRecord::Migration[5.0]
+  def change
+    add_timestamps :profile_summaries
+  end
+end

--- a/db/migrate/20160802020058_create_reports.rb
+++ b/db/migrate/20160802020058_create_reports.rb
@@ -1,0 +1,10 @@
+class CreateReports < ActiveRecord::Migration[5.0]
+  def change
+    create_table :reports do |t|
+      t.references :profile_summary, foreign_key: true
+      t.text :text
+
+      t.timestamps true
+    end
+  end
+end

--- a/db/migrate/20160802024940_create_emotion_tones.rb
+++ b/db/migrate/20160802024940_create_emotion_tones.rb
@@ -1,0 +1,14 @@
+class CreateEmotionTones < ActiveRecord::Migration[5.0]
+  def change
+    create_table :emotion_tones do |t|
+      t.integer :anger
+      t.integer :disgust
+      t.integer :fear
+      t.integer :joy
+      t.integer :sadness
+      t.references :report, foreign_key: true
+
+      t.timestamps true
+    end
+  end
+end

--- a/db/migrate/20160802025259_create_language_tones.rb
+++ b/db/migrate/20160802025259_create_language_tones.rb
@@ -1,0 +1,12 @@
+class CreateLanguageTones < ActiveRecord::Migration[5.0]
+  def change
+    create_table :language_tones do |t|
+      t.integer :analytical
+      t.integer :confident
+      t.integer :tentative
+      t.references :report, foreign_key: true
+
+      t.timestamps true
+    end
+  end
+end

--- a/db/migrate/20160802025420_create_social_tones.rb
+++ b/db/migrate/20160802025420_create_social_tones.rb
@@ -1,0 +1,14 @@
+class CreateSocialTones < ActiveRecord::Migration[5.0]
+  def change
+    create_table :social_tones do |t|
+      t.integer :openness
+      t.integer :conscientiousness
+      t.integer :extraversion
+      t.integer :agreeableness
+      t.integer :emotional_range
+      t.references :report, foreign_key: true
+
+      t.timestamps true 
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,32 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160731172339) do
+ActiveRecord::Schema.define(version: 20160802025420) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "emotion_tones", force: :cascade do |t|
+    t.integer  "anger"
+    t.integer  "disgust"
+    t.integer  "fear"
+    t.integer  "joy"
+    t.integer  "sadness"
+    t.integer  "report_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["report_id"], name: "index_emotion_tones_on_report_id", using: :btree
+  end
+
+  create_table "language_tones", force: :cascade do |t|
+    t.integer  "analytical"
+    t.integer  "confident"
+    t.integer  "tentative"
+    t.integer  "report_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["report_id"], name: "index_language_tones_on_report_id", using: :btree
+  end
 
   create_table "profile_summaries", force: :cascade do |t|
     t.text     "content"
@@ -21,6 +43,26 @@ ActiveRecord::Schema.define(version: 20160731172339) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_profile_summaries_on_user_id", using: :btree
+  end
+
+  create_table "reports", force: :cascade do |t|
+    t.integer  "profile_summary_id"
+    t.text     "text"
+    t.datetime "created_at",         null: false
+    t.datetime "updated_at",         null: false
+    t.index ["profile_summary_id"], name: "index_reports_on_profile_summary_id", using: :btree
+  end
+
+  create_table "social_tones", force: :cascade do |t|
+    t.integer  "openness"
+    t.integer  "conscientiousness"
+    t.integer  "extraversion"
+    t.integer  "agreeableness"
+    t.integer  "emotional_range"
+    t.integer  "report_id"
+    t.datetime "created_at",        null: false
+    t.datetime "updated_at",        null: false
+    t.index ["report_id"], name: "index_social_tones_on_report_id", using: :btree
   end
 
   create_table "users", force: :cascade do |t|
@@ -33,5 +75,9 @@ ActiveRecord::Schema.define(version: 20160731172339) do
     t.string   "last_name"
   end
 
+  add_foreign_key "emotion_tones", "reports"
+  add_foreign_key "language_tones", "reports"
   add_foreign_key "profile_summaries", "users"
+  add_foreign_key "reports", "profile_summaries"
+  add_foreign_key "social_tones", "reports"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160730033910) do
+ActiveRecord::Schema.define(version: 20160731172339) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "profile_summaries", force: :cascade do |t|
-    t.text    "content"
-    t.integer "user_id"
+    t.text     "content"
+    t.integer  "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_profile_summaries_on_user_id", using: :btree
   end
 

--- a/spec/features/user_logs_out_spec.rb
+++ b/spec/features/user_logs_out_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.feature "user logs out" do
+  fixtures :users
+  scenario "by clicking Log Out" do
+    user = users(:erin)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    visit user_path(user)
+    click_link "Log Out"
+
+    expect(current_path).to eq root_path
+    expect(page).to have_content("Log In with LinkedIn")
+    expect(page).not_to have_content("Log Out")
+  end
+end

--- a/spec/features/user_runs_first_report_for_summary_spec.rb
+++ b/spec/features/user_runs_first_report_for_summary_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
 RSpec.feature "user runs first report for summary" do
-  fixtures :users, :profile_summaries, :reports, :language_tones, :emotion_tones, :social_tones
+  fixtures :users, :profile_summaries
   scenario "by clicking the Analyze button" do
     VCR.use_cassette("profile_summary") do
       user = users(:erin)
       summary = profile_summaries(:sample)
-  
+
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
       visit profile_summary_path(summary)

--- a/spec/features/user_runs_first_report_for_summary_spec.rb
+++ b/spec/features/user_runs_first_report_for_summary_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.feature "user runs first report for summary" do
+  fixtures :users, :profile_summaries, :reports, :language_tones, :emotion_tones, :social_tones
+  scenario "by clicking the Analyze button" do
+    VCR.use_cassette("profile_summary") do
+      user = users(:erin)
+      summary = profile_summaries(:sample)
+  
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      visit profile_summary_path(summary)
+
+      within(".profile-summary-form") do
+        expect(page).to have_content "Profile Summary"
+      end
+
+      within("#profile-summary") do
+        expect(page).to have_content summary.content
+      end
+
+      click_button "Analyze"
+      report = Report.last
+
+      expect(current_path).to eq "/profile_summary/reports/#{report.id}"
+
+      within("#report") do
+        expect(page).to have_content("Version #{report.id}")
+        expect(page).to have_content(summary.content)
+
+        within("#emotion") do
+          expect(page).to have_content(report.emotion_tone.anger)
+          expect(page).to have_content(report.emotion_tone.disgust)
+          expect(page).to have_content(report.emotion_tone.fear)
+          expect(page).to have_content(report.emotion_tone.joy)
+          expect(page).to have_content(report.emotion_tone.sadness)
+        end
+
+        within("#language") do
+          expect(page).to have_content(report.language_tone.analytical)
+          expect(page).to have_content(report.language_tone.confident)
+          expect(page).to have_content(report.language_tone.tentative)
+        end
+
+        within("#social") do
+          expect(page).to have_content(report.social_tone.openness)
+          expect(page).to have_content(report.social_tone.conscientiousness)
+          expect(page).to have_content(report.social_tone.extraversion)
+          expect(page).to have_content(report.social_tone.agreeableness)
+          expect(page).to have_content(report.social_tone.emotional_range)
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/emotion_tones.yml
+++ b/spec/fixtures/emotion_tones.yml
@@ -1,0 +1,7 @@
+one:
+  anger: 369
+  disgust: 141
+  fear: 82
+  joy: 525
+  sadness: 115
+  report: version_one

--- a/spec/fixtures/language_tones.yml
+++ b/spec/fixtures/language_tones.yml
@@ -1,0 +1,5 @@
+one:
+  analytical: 472
+  confident: 963
+  tentative: 0
+  report: version_one

--- a/spec/fixtures/profile_summaries.yml
+++ b/spec/fixtures/profile_summaries.yml
@@ -1,0 +1,3 @@
+sample:
+  content: A word is dead when it is said, some say.
+  user: erin

--- a/spec/fixtures/profile_summaries.yml
+++ b/spec/fixtures/profile_summaries.yml
@@ -1,3 +1,3 @@
 sample:
-  content: A word is dead when it is said, some say.
+  content: I set extremely high standards for my work, and I inspire others to do the same. I always meet deadlines, and I produce top-notch results. I consistently raise the bar at every organization I work with. Looking for excellence? Let's get in touch.
   user: erin

--- a/spec/fixtures/reports.yml
+++ b/spec/fixtures/reports.yml
@@ -1,0 +1,2 @@
+version_one:
+  profile_summary: sample

--- a/spec/fixtures/reports.yml
+++ b/spec/fixtures/reports.yml
@@ -1,2 +1,3 @@
 version_one:
-  profile_summary: sample
+    text: I set extremely high standards for my work, and I inspire others to do the same. I always meet deadlines, and I produce top-notch results. I consistently raise the bar at every organization I work with. Looking for excellence? Let's get in touch.
+    profile_summary : sample

--- a/spec/fixtures/social_tones.yml
+++ b/spec/fixtures/social_tones.yml
@@ -1,0 +1,7 @@
+one:
+  openness: 53
+  conscientiousness: 936
+  extraversion: 194
+  agreeableness: 896
+  emotional_range: 973
+  report: version_one

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -3,4 +3,4 @@ erin:
   name: Erin Greenhalgh
   first_name: Erin
   last_name: Greenhalgh
-  oauth_token: ENV["user_token"]
+  oauth_token: <%= ENV["user_token"] %> 

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -3,4 +3,11 @@ erin:
   name: Erin Greenhalgh
   first_name: Erin
   last_name: Greenhalgh
-  oauth_token: <%= ENV["user_token"] %> 
+  oauth_token: <%= ENV["user_token"] %>
+
+weirdo:
+  uid: 1234
+  name: Erin Greenhalgh
+  first_name: w!eIrdO.
+  last_name: Greenhalgh
+  oauth_token: <%= ENV["user_token"] %>

--- a/spec/models/emotion_tone_spec.rb
+++ b/spec/models/emotion_tone_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe EmotionTone, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it { should belong_to :report }
 end

--- a/spec/models/emotion_tone_spec.rb
+++ b/spec/models/emotion_tone_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe EmotionTone, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/language_tone_spec.rb
+++ b/spec/models/language_tone_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe LanguageTone, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it { should belong_to :report }
 end

--- a/spec/models/language_tone_spec.rb
+++ b/spec/models/language_tone_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe LanguageTone, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/profile_summary_spec.rb
+++ b/spec/models/profile_summary_spec.rb
@@ -1,14 +1,15 @@
 require "rails_helper"
 
 RSpec.describe "profile summary" do
-  fixtures :users
+  fixtures :users, :profile_summaries
 
   it "creates a profile summary instance in db from API data" do
     VCR.use_cassette(:profile_summary) do
       user = users(:erin)
+      summary = profile_summaries(:sample)
 
       ps = ProfileSummary.get_text(user)
-      expect(ProfileSummary.first.content[0..14]).to eq "I set extremely"
+      expect(ProfileSummary.first.content).to eq summary.content
     end
   end
 

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Report, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -1,5 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Report, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it { should validate_presence_of(:text) }
+  it { should belong_to(:profile_summary) }
+  it { should have_one(:emotion_tone) }
+  it { should have_one(:language_tone) }
+  it { should have_one(:social_tone) }
 end

--- a/spec/models/social_tone_spec.rb
+++ b/spec/models/social_tone_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe SocialTone, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/social_tone_spec.rb
+++ b/spec/models/social_tone_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe SocialTone, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it { should respond_to :report }
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  fixtures :users
+  it { should have_one :profile_summary }
+
+  it "overrides the param method with the user's first name" do
+    user = users(:weirdo)
+    expect(user.to_param).to eq "w-eirdo"
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,12 +10,21 @@ require 'rspec/rails'
 require 'capybara/rspec'
 require 'capybara/rails'
 require 'vcr'
+require "database_cleaner"
 
 VCR.configure do |c|
   c.cassette_library_dir = 'spec/cassettes'
   c.hook_into :webmock
   c.configure_rspec_metadata!
 end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end
+
 
 
 # Add additional requires below this line. Rails is not loaded until this point!

--- a/spec/services/linkedin_service_spec.rb
+++ b/spec/services/linkedin_service_spec.rb
@@ -2,12 +2,12 @@ require 'rails_helper'
 
 RSpec.describe "linkedin service" do
   fixtures :users
-  let(:linkedin_service) { LinkedinService.new }
 
   scenario "returns the user's summary" do
     VCR.use_cassette("profile_summary") do
       user = users(:erin)
-      data = linkedin_service.get_profile_information(user.oauth_token)
+      linkedin_service = LinkedinService.new(user.oauth_token)
+      data = linkedin_service.get_profile_information
       expect(data.keys.count).to eq 1
       expect(data["summary"]).to be_truthy
     end

--- a/spec/services/report_generator_service_spec.rb
+++ b/spec/services/report_generator_service_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe "report generator service" do
+  fixtures :users, :profile_summaries, :reports
+  let(:generator) { ReportGeneratorService.new }
+
+
+  it "creates a report entry in the database" do
+    user = users(:erin)
+    summary = profile_summaries(:sample)
+
+    generator.create_report_entry(user)
+    expect(Report.first.text).to eq summary.content
+  end
+
+  it "creates an emption tone object associated with a report" do
+    user = users(:erin)
+    report = reports(:version_one)
+    tone = generator.create_emotion_tone(user, report)
+    expect(tone.class).to eq EmotionTone
+    expect(EmotionTone.count).to eq 1
+    expect(tone.report).to eq report
+  end
+
+  it "creates associated language tone object based on a report" do
+    user = users(:erin)
+    report = reports(:version_one)
+    tone = generator.create_language_tone(user, report)
+    expect(tone.class).to eq LanguageTone
+    expect(LanguageTone.count).to eq 1
+    expect(tone.report).to eq report
+  end
+
+  it "create associated social tone object based on a report" do
+    user = users(:erin)
+    report = reports(:version_one)
+    tone = generator.create_social_tone(user, report)
+    expect(tone.class).to eq SocialTone
+    expect(SocialTone.count).to eq 1
+    expect(tone.report).to eq report
+  end
+
+  it "creates all associated tone objects for a report" do
+    user = users(:erin)
+    report = reports(:version_one)
+    generator.create_tone_reports(user, report)
+    expect(EmotionTone.count).to eq 1
+    expect(LanguageTone.count).to eq 1
+    expect(SocialTone.count).to eq 1
+  end 
+end

--- a/spec/services/tone_analyzer_service_spec.rb
+++ b/spec/services/tone_analyzer_service_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe "tone analyzer service" do
+  fixtures :users, :profile_summaries
+  it "gets the tone report data for the user's profile summary" do
+    VCR.use_cassette("tone_report") do
+      user = users(:erin)
+      summary = profile_summaries(:sample)
+      report = ToneAnalyzerService.new.analyze_text(user)
+
+      expect(report["document_tone"].keys).to eq ["tone_categories"]
+    end
+  end
+end

--- a/spec/services/tone_data_formatter_service_spec.rb
+++ b/spec/services/tone_data_formatter_service_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "tone data formatter service" do
   fixtures :users, :profile_summaries
 
-  let(:user) { users(:erin) }
+  let(:user)      { users(:erin) }
   let(:formatter) { ToneDataFormatterService.new }
 
   it "isolates an array of tone categories" do
@@ -35,11 +35,11 @@ RSpec.describe "tone data formatter service" do
   end
 
   it "finds social attributes" do
-    attributes = {"openness_big5"          => 190,
-                  "conscientiousness_big5" => 66,
-                  "extraversion_big5"      => 904,
-                  "agreeableness_big5"     => 320,
-                  "emotional_range_big5"   => 489}
+    attributes = {"openness"          => 190,
+                  "conscientiousness" => 66,
+                  "extraversion"      => 904,
+                  "agreeableness"     => 320,
+                  "emotional_range"   => 489}
     expect(formatter.social_attributes(user)).to eq attributes
   end
 end

--- a/spec/services/tone_data_formatter_service_spec.rb
+++ b/spec/services/tone_data_formatter_service_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe "tone data formatter service" do
+  fixtures :users, :profile_summaries
+
+  let(:user) { users(:erin) }
+  let(:formatter) { ToneDataFormatterService.new }
+
+  it "isolates an array of tone categories" do
+    VCR.use_cassette("tone_report") do
+      expect(formatter.categories(user).count).to eq 3
+    end
+  end
+
+  it "finds tones by category" do
+      expect(formatter.emotion_tones(user)["category_id"]).to eq "emotion_tone"
+      expect(formatter.language_tones(user)["category_id"]).to eq "language_tone"
+      expect(formatter.social_tones(user)["category_id"]).to eq "social_tone"
+  end
+
+  it "finds emotion attributes" do
+    attributes = {"anger"   => 429,
+                  "disgust" => 231,
+                  "fear"    => 288,
+                  "joy"     => 28,
+                  "sadness" => 620}
+    expect(formatter.emotion_attributes(user)).to eq attributes
+  end
+
+  it "finds language attributes" do
+    attributes = {"analytical" => 0,
+                  "confident"  => 0,
+                  "tentative"  => 715}
+    expect(formatter.language_attributes(user)).to eq attributes
+  end
+
+  it "finds social attributes" do
+    attributes = {"openness_big5"          => 190,
+                  "conscientiousness_big5" => 66,
+                  "extraversion_big5"      => 904,
+                  "agreeableness_big5"     => 320,
+                  "emotional_range_big5"   => 489}
+    expect(formatter.social_attributes(user)).to eq attributes
+  end
+end

--- a/spec/services/tone_data_formatter_service_spec.rb
+++ b/spec/services/tone_data_formatter_service_spec.rb
@@ -19,27 +19,27 @@ RSpec.describe "tone data formatter service" do
   end
 
   it "finds emotion attributes" do
-    attributes = {"anger"   => 429,
-                  "disgust" => 231,
-                  "fear"    => 288,
-                  "joy"     => 28,
-                  "sadness" => 620}
+    attributes = {"anger"   => 369,
+                  "disgust" => 141,
+                  "fear"    => 82,
+                  "joy"     => 525,
+                  "sadness" => 115}
     expect(formatter.emotion_attributes(user)).to eq attributes
   end
 
   it "finds language attributes" do
-    attributes = {"analytical" => 0,
-                  "confident"  => 0,
-                  "tentative"  => 715}
+    attributes = {"analytical" => 472,
+                  "confident"  => 963,
+                  "tentative"  => 0}
     expect(formatter.language_attributes(user)).to eq attributes
   end
 
   it "finds social attributes" do
-    attributes = {"openness"          => 190,
-                  "conscientiousness" => 66,
-                  "extraversion"      => 904,
-                  "agreeableness"     => 320,
-                  "emotional_range"   => 489}
+    attributes = {"openness"          => 53,
+                  "conscientiousness" => 936,
+                  "extraversion"      => 194,
+                  "agreeableness"     => 896,
+                  "emotional_range"   => 973}
     expect(formatter.social_attributes(user)).to eq attributes
   end
 end


### PR DESCRIPTION
Creates a tone formatter service that takes in the content from the user's profile summary and feeds it to the Watson Tone Analyzer API. The data that comes back is formatted by a formatter service and then passed to a report generator service that creates a report and associated tone objects. 

From the front-end, the user is able to click an analyze button that sends the text of the report to the API through a create_report method in the profile summaries controller.

Data that is currently displaying to views is unformatted. Needs styling. 

All code fully tested. Some refactoring of services and minor tweaks to styling. 

Renamed databases and config details to write_link instead of personal_project. This was causing some problems in production and may yet need to be resolved. 
